### PR TITLE
Added Tinc support

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	defaultInstanceCount  = 3
-	defaultGluonImage     = "pulcy/gluon:0.14.6"
+	defaultGluonImage     = "pulcy/gluon:0.14.7"
 	defaultRebootStrategy = "etcd-lock"
 	defaultMinOSVersion   = "835.13.0"
 )

--- a/instance_create.go
+++ b/instance_create.go
@@ -104,7 +104,7 @@ func createInstance(cmd *cobra.Command, args []string) {
 		if err != nil {
 			Exitf("Failed to get machine ID: %v\n", err)
 		}
-		if err := instances[0].AddEtcdMember(log, newMachineID, instance.PrivateIpv4); err != nil {
+		if err := instances[0].AddEtcdMember(log, newMachineID, instance.ClusterIP); err != nil {
 			Exitf("Failed to add new instance to etcd: %v\n", err)
 		}
 	}
@@ -114,7 +114,7 @@ func createInstance(cmd *cobra.Command, args []string) {
 
 	// Load cluster-members data
 	isEtcdProxy := func(i providers.ClusterInstance) bool {
-		return createInstanceFlags.EtcdProxy && (i.PrivateIpv4 == instance.PrivateIpv4)
+		return createInstanceFlags.EtcdProxy && (i.ClusterIP == instance.ClusterIP)
 	}
 	clusterMembers, err := instances.AsClusterMemberList(log, isEtcdProxy)
 	if err != nil {
@@ -126,7 +126,7 @@ func createInstance(cmd *cobra.Command, args []string) {
 		ClusterMembers: clusterMembers,
 		FleetMetadata:  createInstanceFlags.CreateFleetMetadata(createInstanceFlags.InstanceIndex),
 	}
-	if err := instance.InitialSetup(log, createInstanceFlags, iso); err != nil {
+	if err := instance.InitialSetup(log, createInstanceFlags, iso, provider); err != nil {
 		Exitf("Failed to perform initial instance setup: %v\n", err)
 	}
 
@@ -136,7 +136,7 @@ func createInstance(cmd *cobra.Command, args []string) {
 	}
 
 	// Reboot new instance
-	if err := instance.Reboot(log); err != nil {
+	if err := provider.RebootInstance(instance); err != nil {
 		Exitf("Failed to reboot new instance: %v\n", err)
 	}
 

--- a/instance_list.go
+++ b/instance_list.go
@@ -57,14 +57,15 @@ func showInstances(cmd *cobra.Command, args []string) {
 		Exitf("Failed to fetch instance member data: %v\n", err)
 	}
 
-	lines := []string{"Name | Private IP | Public IP | Machine ID | Options"}
+	lines := []string{"Name | Cluster IP | Public IP | Private IP | Machine ID | Options"}
 	for _, i := range instances {
 		cm, _ := clusterMembers.Find(i) // ignore errors
 		options := []string{}
 		if cm.EtcdProxy {
 			options = append(options, "etcd-proxy")
 		}
-		lines = append(lines, fmt.Sprintf("%s | %s | %s | %s | %s", i.Name, i.PrivateIpv4, i.PublicIpv4, cm.MachineID, strings.Join(options, ",")))
+		lbIP := strings.TrimSpace(i.LoadBalancerIPv4 + " " + i.LoadBalancerIPv6)
+		lines = append(lines, fmt.Sprintf("%s | %s | %s | %s | %s", i.Name, i.ClusterIP, lbIP, i.PrivateIP, cm.MachineID, strings.Join(options, ",")))
 	}
 	result := columnize.SimpleFormat(lines)
 	fmt.Println(result)

--- a/instance_list.go
+++ b/instance_list.go
@@ -65,7 +65,7 @@ func showInstances(cmd *cobra.Command, args []string) {
 			options = append(options, "etcd-proxy")
 		}
 		lbIP := strings.TrimSpace(i.LoadBalancerIPv4 + " " + i.LoadBalancerIPv6)
-		lines = append(lines, fmt.Sprintf("%s | %s | %s | %s | %s", i.Name, i.ClusterIP, lbIP, i.PrivateIP, cm.MachineID, strings.Join(options, ",")))
+		lines = append(lines, fmt.Sprintf("%s | %s | %s | %s | %s | %s", i.Name, i.ClusterIP, lbIP, i.PrivateIP, cm.MachineID, strings.Join(options, ",")))
 	}
 	result := columnize.SimpleFormat(lines)
 	fmt.Println(result)

--- a/providers/cloud_provider.go
+++ b/providers/cloud_provider.go
@@ -30,6 +30,10 @@ var (
 	maskAny = errgo.MaskFunc(errgo.Any)
 )
 
+const (
+	tincAddressTemplate = "192.168.35.%d"
+)
+
 // DnsProvider holds all functions to be implemented by DNS providers
 type DnsProvider interface {
 	ShowDomainRecords(domain string) error
@@ -99,8 +103,14 @@ type ClusterInstance struct {
 	PublicIpv4           string
 	PublicIpv6           string
 	PrivateClusterDevice string
+	TincIpv4             string
 	UserName             string
 	NoCoreOS             bool
+}
+
+// Name of the instance in Tinc
+func (o ClusterInstance) TincName() string {
+	return strings.Replace(strings.Replace(o.Name, ".", "_", -1), "-", "_", -1)
 }
 
 type InstanceConfig struct {
@@ -163,6 +173,7 @@ func (o *CreateClusterOptions) NewCreateInstanceOptions(isCore, isLB bool, insta
 		PrivateRegistryPassword: o.PrivateRegistryPassword,
 		VaultAddress:            o.VaultAddress,
 		VaultCertificate:        vaultCertificate,
+		TincIpv4:                fmt.Sprintf(tincAddressTemplate, instanceIndex),
 	}
 	io.SetupNames(o.instancePrefixes[instanceIndex-1], o.Name, o.Domain)
 	return io, nil
@@ -187,6 +198,7 @@ type CreateInstanceOptions struct {
 	EtcdProxy               bool   // If set, this instance will be an ETCD proxy
 	VaultAddress            string // URL of the vault
 	VaultCertificate        string // Contents of the vault ca-cert
+	TincIpv4                string // IP addres of tun0 (tinc) on this instance
 }
 
 // SetupNames configured the ClusterName and InstanceName of the given options

--- a/providers/cloud_provider.go
+++ b/providers/cloud_provider.go
@@ -72,6 +72,9 @@ type CloudProvider interface {
 	// Remove a single instance of a cluster
 	DeleteInstance(info ClusterInstanceInfo, dnsProvider DnsProvider) error
 
+	// Perform a reboot of the given instance
+	RebootInstance(instance ClusterInstance) error
+
 	ShowDomainRecords(domain string) error
 }
 
@@ -94,23 +97,6 @@ type ClusterInstanceInfo struct {
 
 func (cii ClusterInstanceInfo) String() string {
 	return fmt.Sprintf("%s.%s.%s", cii.Prefix, cii.Name, cii.Domain)
-}
-
-// ClusterInstance describes a single instance
-type ClusterInstance struct {
-	Name                 string
-	PrivateIpv4          string
-	PublicIpv4           string
-	PublicIpv6           string
-	PrivateClusterDevice string
-	TincIpv4             string
-	UserName             string
-	NoCoreOS             bool
-}
-
-// Name of the instance in Tinc
-func (o ClusterInstance) TincName() string {
-	return strings.Replace(strings.Replace(o.Name, ".", "_", -1), "-", "_", -1)
 }
 
 type InstanceConfig struct {

--- a/providers/cluster_member.go
+++ b/providers/cluster_member.go
@@ -19,10 +19,10 @@ import (
 )
 
 type ClusterMember struct {
-	ClusterID string
-	MachineID string
-	PrivateIP string
-	EtcdProxy bool
+	ClusterID string // ID of the cluster this is a member of (/etc/pulcu/cluster-id)
+	MachineID string // ID of the machine (/etc/machine-id)
+	ClusterIP string // IP address of the instance used for all private communication in the cluster
+	EtcdProxy bool   // If set, this member is an ETCD proxy
 }
 
 type ClusterMemberList []ClusterMember
@@ -34,14 +34,14 @@ func (cml ClusterMemberList) Render() string {
 		if cm.EtcdProxy {
 			proxy = " etcd-proxy"
 		}
-		data = data + fmt.Sprintf("%s=%s%s\n", cm.MachineID, cm.PrivateIP, proxy)
+		data = data + fmt.Sprintf("%s=%s%s\n", cm.MachineID, cm.ClusterIP, proxy)
 	}
 	return data
 }
 
 func (cml ClusterMemberList) Find(instance ClusterInstance) (ClusterMember, error) {
 	for _, cm := range cml {
-		if cm.PrivateIP == instance.PrivateIpv4 {
+		if cm.ClusterIP == instance.ClusterIP {
 			return cm, nil
 		}
 	}

--- a/providers/digitalocean/create.go
+++ b/providers/digitalocean/create.go
@@ -101,7 +101,7 @@ func (dp *doProvider) setupInstances(log *logging.Logger, instances []instanceDa
 				ClusterMembers: clusterMembers,
 				FleetMetadata:  instance.FleetMetadata,
 			}
-			if err := instance.ClusterInstance.InitialSetup(log, instance.CreateInstanceOptions, iso); err != nil {
+			if err := instance.ClusterInstance.InitialSetup(log, instance.CreateInstanceOptions, iso, dp); err != nil {
 				errors <- maskAny(err)
 				return
 			}

--- a/providers/digitalocean/instances.go
+++ b/providers/digitalocean/instances.go
@@ -57,11 +57,13 @@ func (dp *doProvider) getInstances(info providers.ClusterInfo) ([]godo.Droplet, 
 // clusterInstance creates a ClusterInstance record for the given droplet
 func (dp *doProvider) clusterInstance(d godo.Droplet) providers.ClusterInstance {
 	info := providers.ClusterInstance{
-		Name:                 d.Name,
-		PrivateIpv4:          getIpv4(d, "private"),
-		PublicIpv4:           getIpv4(d, "public"),
-		PublicIpv6:           getIpv6(d, "public"),
-		PrivateClusterDevice: privateClusterDevice,
+		Name:             d.Name,
+		ClusterIP:        getIpv4(d, "private"),
+		PrivateIP:        getIpv4(d, "private"),
+		LoadBalancerIPv4: getIpv4(d, "public"),
+		LoadBalancerIPv6: getIpv6(d, "public"),
+		ClusterDevice:    privateClusterDevice,
+		OS:               providers.OSNameCoreOS,
 	}
 	return info
 }

--- a/providers/digitalocean/reboot.go
+++ b/providers/digitalocean/reboot.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digitalocean
+
+import (
+	"github.com/pulcy/quark/providers"
+)
+
+// Perform a reboot of the given instance
+func (vp *doProvider) RebootInstance(instance providers.ClusterInstance) error {
+	if _, err := instance.Exec(vp.Logger, "sudo shutdown -r now"); err != nil {
+		return maskAny(err)
+	}
+	return nil
+}

--- a/providers/instance.go
+++ b/providers/instance.go
@@ -350,7 +350,7 @@ func (i ClusterInstance) UpdateClusterMembers(log *logging.Logger, members Clust
 	}
 
 	log.Infof("Enabling services on %s", i)
-	services := []string{"etcd2.service", "fleet.service", "fleet.socket"}
+	services := []string{"etcd2.service", "fleet.service", "fleet.socket", "ip4tables.service", "ip6tables.service"}
 	for _, service := range services {
 		if err := i.EnableService(log, service); err != nil {
 			return maskAny(err)

--- a/providers/scaleway/create.go
+++ b/providers/scaleway/create.go
@@ -130,7 +130,10 @@ func (vp *scalewayProvider) createServer(options providers.CreateInstanceOptions
 		Volumes:           map[string]string{},
 		DynamicIPRequired: &dynamicIPRequired,
 		//Bootscript:        &bootscript,
-		Tags:           []string{options.ClusterInfo.ID},
+		Tags: []string{
+			options.ClusterInfo.ID,
+			options.TincIpv4,
+		},
 		Organization:   vp.organization,
 		CommercialType: options.TypeID,
 		PublicIP:       publicIPIdentifier,

--- a/providers/scaleway/defaults.go
+++ b/providers/scaleway/defaults.go
@@ -21,12 +21,12 @@ import (
 const (
 	regionParis       = "fr-1"
 	dockerImageID     = "docker"
-	commercialTypeVC1 = "VC1"
+	commercialTypeVC1 = "VC1S"
 	commercialTypeC2S = "C2S"
 	commercialTypeC2M = "C2M"
 	commercialTypeC2L = "C2L"
 
-	privateClusterDevice = "eth0"
+	privateClusterDevice = "tun0"
 )
 
 // Apply defaults for the given options

--- a/providers/scaleway/delete.go
+++ b/providers/scaleway/delete.go
@@ -22,7 +22,7 @@ import (
 
 // Remove all instances of a cluster
 func (vp *scalewayProvider) DeleteCluster(info providers.ClusterInfo, dnsProvider providers.DnsProvider) error {
-	servers, err := vp.getInstances(info)
+	servers, err := vp.getServers(info)
 	if err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func (vp *scalewayProvider) DeleteCluster(info providers.ClusterInfo, dnsProvide
 
 func (vp *scalewayProvider) DeleteInstance(info providers.ClusterInstanceInfo, dnsProvider providers.DnsProvider) error {
 	fullName := info.String()
-	servers, err := vp.getInstances(info.ClusterInfo)
+	servers, err := vp.getServers(info.ClusterInfo)
 	if err != nil {
 		return maskAny(err)
 	}

--- a/providers/scaleway/instances.go
+++ b/providers/scaleway/instances.go
@@ -25,20 +25,20 @@ import (
 
 // Get names of instances of a cluster
 func (vp *scalewayProvider) GetInstances(info providers.ClusterInfo) (providers.ClusterInstanceList, error) {
-	servers, err := vp.getInstances(info)
+	servers, err := vp.getServers(info)
 	if err != nil {
 		return nil, maskAny(err)
 	}
 	list := providers.ClusterInstanceList{}
 	for _, s := range servers {
-		info := vp.clusterInstance(s, false)
-		list = append(list, info)
+		instance := vp.clusterInstance(s, false)
+		list = append(list, instance)
 
 	}
 	return list, nil
 }
 
-func (vp *scalewayProvider) getInstances(info providers.ClusterInfo) ([]api.ScalewayServer, error) {
+func (vp *scalewayProvider) getServers(info providers.ClusterInfo) ([]api.ScalewayServer, error) {
 	all := true
 	limit := 999
 	servers, err := vp.client.GetServers(all, limit)
@@ -61,12 +61,14 @@ func (vp *scalewayProvider) getInstances(info providers.ClusterInfo) ([]api.Scal
 func (dp *scalewayProvider) clusterInstance(s api.ScalewayServer, bootstrapNeeded bool) providers.ClusterInstance {
 	publicIPv4 := s.PublicAddress.IP
 	info := providers.ClusterInstance{
-		Name:                 s.Name,
-		PrivateIpv4:          s.PrivateIP,
-		PublicIpv4:           publicIPv4,
-		PublicIpv6:           "",
-		PrivateClusterDevice: privateClusterDevice,
-		NoCoreOS:             true,
+		ID:               s.Identifier,
+		Name:             s.Name,
+		ClusterIP:        s.Tags[clusterIPTagIndex],
+		PrivateIP:        s.PrivateIP,
+		LoadBalancerIPv4: publicIPv4,
+		LoadBalancerIPv6: "",
+		ClusterDevice:    privateClusterDevice,
+		OS:               providers.OSNameUbuntu,
 	}
 	if bootstrapNeeded {
 		info.UserName = "root"

--- a/providers/scaleway/reboot.go
+++ b/providers/scaleway/reboot.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scaleway
+
+import (
+	"github.com/pulcy/quark/providers"
+)
+
+// Perform a reboot of the given instance
+func (vp *scalewayProvider) RebootInstance(instance providers.ClusterInstance) error {
+	if err := instance.Sync(vp.Logger); err != nil {
+		return maskAny(err)
+	}
+	if err := vp.client.PostServerAction(instance.ID, "reboot"); err != nil {
+		vp.Logger.Errorf("reboot failed: %#v", err)
+		return maskAny(err)
+	}
+	return nil
+}

--- a/providers/tinc.go
+++ b/providers/tinc.go
@@ -1,0 +1,244 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"fmt"
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/op/go-logging"
+)
+
+// UpdateClusterMembers updates /etc/cluster-members on all instances of the cluster
+func ReconfigureTincCluster(log *logging.Logger, info ClusterInfo, provider CloudProvider) error {
+	// Load all instances
+	instances, err := provider.GetInstances(info)
+	if err != nil {
+		return maskAny(err)
+	}
+
+	// Call reconfigure-tinc-host on all instances
+	if instances.ReconfigureTincCluster(log); err != nil {
+		return maskAny(err)
+	}
+
+	return nil
+}
+
+// UpdateClusterMembers updates /etc/cluster-members on all instances of the cluster
+func (instances ClusterInstanceList) ReconfigureTincCluster(log *logging.Logger) error {
+	// Now update all members in parallel
+	vpnName := "pulcy"
+	wg := sync.WaitGroup{}
+	errorChannel := make(chan error, len(instances))
+	for _, i := range instances {
+		wg.Add(1)
+		go func(i ClusterInstance) {
+			defer wg.Done()
+			if err := i.configureTincHost(log, vpnName, instances); err != nil {
+				errorChannel <- maskAny(err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errorChannel)
+	for err := range errorChannel {
+		return maskAny(err)
+	}
+
+	for _, x := range instances {
+		if err := x.distributeTincHosts(log, vpnName, instances); err != nil {
+			return maskAny(err)
+		}
+	}
+
+	return nil
+}
+
+func (i ClusterInstance) configureTincHost(log *logging.Logger, vpnName string, instances ClusterInstanceList) error {
+	connectTo := []string{}
+	for _, x := range instances {
+		if x.Name != i.Name {
+			connectTo = append(connectTo, x.PrivateIpv4)
+		}
+	}
+	if err := i.CreateTincConf(log, vpnName, connectTo); err != nil {
+		return maskAny(err)
+	}
+	if err := i.CreateTincHostConf(log, vpnName); err != nil {
+		return maskAny(err)
+	}
+	if err := i.CreateTincScripts(log, vpnName); err != nil {
+		return maskAny(err)
+	}
+	if err := i.CreateTincService(log, vpnName); err != nil {
+		return maskAny(err)
+	}
+	//Create key
+	if _, err := i.runRemoteCommand(log, fmt.Sprintf("sudo tincd -n %s -K", vpnName), "", false); err != nil {
+		return maskAny(err)
+	}
+	return nil
+}
+
+func (i ClusterInstance) distributeTincHosts(log *logging.Logger, vpnName string, instances ClusterInstanceList) error {
+	conf, err := i.GetTincHostConf(log, vpnName)
+	if err != nil {
+		return maskAny(err)
+	}
+	for _, x := range instances {
+		if x.Name != i.Name {
+			err := i.SetTincHostConf(log, vpnName, i.TincName(), conf)
+			if err != nil {
+				return maskAny(err)
+			}
+		}
+	}
+	return nil
+}
+
+func (i ClusterInstance) GetTincIP(log *logging.Logger) (string, error) {
+	log.Debugf("Fetching tinc-ip on %s", i.PublicIpv4)
+	id, err := i.runRemoteCommand(log, "cat /etc/pulcy/tinc-ip", "", false)
+	return id, maskAny(err)
+}
+
+func (i ClusterInstance) SetTincIP(log *logging.Logger) (string, error) {
+	log.Debugf("Writing tinc-ip on %s", i.PublicIpv4)
+	id, err := i.runRemoteCommand(log, "sudo tee /etc/pulcy/tinc-ip", i.TincIpv4, false)
+	return id, maskAny(err)
+}
+
+// CreateTincConf creates a tinc.conf for the host of the given instance
+func (i ClusterInstance) CreateTincConf(log *logging.Logger, vpnName string, connectTo []string) error {
+	lines := []string{
+		fmt.Sprintf("Name = %s", i.TincName()),
+		"AddressFamily = ipv4",
+		"Interface = tun0",
+	}
+	for _, name := range connectTo {
+		lines = append(lines, fmt.Sprintf("ConnectTo = %s", name))
+	}
+	confDir := path.Join("/etc/tinc", vpnName)
+	confPath := path.Join(confDir, "tinc.conf")
+	if _, err := i.runRemoteCommand(log, fmt.Sprintf("sudo mkdir %s", confDir), "", false); err != nil {
+		return maskAny(err)
+	}
+	if _, err := i.runRemoteCommand(log, fmt.Sprintf("sudo tee %s", confPath), strings.Join(lines, "\n"), false); err != nil {
+		return maskAny(err)
+	}
+	return nil
+}
+
+// CreateTincConf creates a /etc/tinc/<vpnName>/hosts/<hostName> for the host of the given instance
+func (i ClusterInstance) CreateTincHostConf(log *logging.Logger, vpnName string) error {
+	lines := []string{
+		fmt.Sprintf("Address = %s", i.PrivateIpv4),
+		fmt.Sprintf("Subnet = %s/32", i.TincIpv4),
+	}
+	confDir := path.Join("/etc/tinc", vpnName, "hosts")
+	confPath := path.Join(confDir, i.TincName())
+	if _, err := i.runRemoteCommand(log, fmt.Sprintf("sudo mkdir %s", confDir), "", false); err != nil {
+		return maskAny(err)
+	}
+	if _, err := i.runRemoteCommand(log, fmt.Sprintf("sudo tee %s", confPath), strings.Join(lines, "\n"), false); err != nil {
+		return maskAny(err)
+	}
+	return nil
+}
+
+// CreateTincScripts creates a /etc/tinc/<vpnName>/tinc-up|down for the host of the given instance
+func (i ClusterInstance) CreateTincScripts(log *logging.Logger, vpnName string) error {
+	upLines := []string{
+		"#!/bin/sh",
+		fmt.Sprintf("ifconfig $INTERFACE %s netmask 255.255.255.0", i.TincIpv4),
+	}
+	downLines := []string{
+		"#!/bin/sh",
+		"ifconfig $INTERFACE down",
+	}
+	confDir := path.Join("/etc/tinc", vpnName)
+	upPath := path.Join(confDir, "tinc-up")
+	downPath := path.Join(confDir, "tinc-down")
+	if _, err := i.runRemoteCommand(log, fmt.Sprintf("sudo mkdir %s", confDir), "", false); err != nil {
+		return maskAny(err)
+	}
+	if _, err := i.runRemoteCommand(log, fmt.Sprintf("sudo tee %s", upPath), strings.Join(upLines, "\n"), false); err != nil {
+		return maskAny(err)
+	}
+	if _, err := i.runRemoteCommand(log, fmt.Sprintf("sudo tee %s", downPath), strings.Join(downLines, "\n"), false); err != nil {
+		return maskAny(err)
+	}
+	if _, err := i.runRemoteCommand(log, fmt.Sprintf("sudo chmod 755 %s %s", upPath, downPath), "", false); err != nil {
+		return maskAny(err)
+	}
+	return nil
+}
+
+// GetTincHostConf reads a /etc/tinc/<vpnName>/hosts/<hostName> for the host of the given instance
+func (i ClusterInstance) GetTincHostConf(log *logging.Logger, vpnName string) (string, error) {
+	confDir := path.Join("/etc/tinc", vpnName, "hosts")
+	confPath := path.Join(confDir, i.TincName())
+	content, err := i.runRemoteCommand(log, "cat "+confPath, "", false)
+	if err != nil {
+		return "", maskAny(err)
+	}
+	return content, nil
+}
+
+// SetTincHostConf creates a /etc/tinc/<vpnName>/hosts/<hostName> from the given content
+func (i ClusterInstance) SetTincHostConf(log *logging.Logger, vpnName, tincName, content string) error {
+	confDir := path.Join("/etc/tinc", vpnName, "hosts")
+	confPath := path.Join(confDir, tincName)
+	if _, err := i.runRemoteCommand(log, fmt.Sprintf("sudo mkdir %s", confDir), "", false); err != nil {
+		return maskAny(err)
+	}
+	if _, err := i.runRemoteCommand(log, fmt.Sprintf("sudo tee %s", confPath), content, false); err != nil {
+		return maskAny(err)
+	}
+	return nil
+}
+
+// CreateTincConf creates a /etc/tinc/<vpnName>/hosts/<hostName> for the host of the given instance
+func (i ClusterInstance) CreateTincService(log *logging.Logger, vpnName string) error {
+	lines := []string{
+		"[Unit]",
+		fmt.Sprintf("Description=tinc for network %s", vpnName),
+		"After=local-fs.target network-pre.target networking.service",
+		"Before=network.target",
+		"",
+		"[Service]",
+		"Type=simple",
+		fmt.Sprintf("ExecStart=/usr/sbin/tincd -D -n %s", vpnName),
+		fmt.Sprintf("ExecReload=/usr/sbin/tincd -n %s reload", vpnName),
+		fmt.Sprintf("ExecStop=/usr/sbin/tincd -n %s stop", vpnName),
+		"TimeoutStopSec=5",
+		"Restart=always",
+		"RestartSec=60",
+		"",
+		"[Install]",
+		"WantedBy=multi-user.target",
+	}
+	confPath := "/etc/systemd/system/tinc.service"
+	if _, err := i.runRemoteCommand(log, fmt.Sprintf("sudo tee %s", confPath), strings.Join(lines, "\n"), false); err != nil {
+		return maskAny(err)
+	}
+	if _, err := i.runRemoteCommand(log, "sudo systemctl enable tinc.service", "", false); err != nil {
+		return maskAny(err)
+	}
+	return nil
+}

--- a/providers/update_cluster.go
+++ b/providers/update_cluster.go
@@ -35,7 +35,7 @@ func UpdateClusterMembers(log *logging.Logger, info ClusterInfo, rebootAfter boo
 	}
 
 	// Call update-member on all instances
-	if instances.UpdateClusterMembers(log, clusterMembers, rebootAfter); err != nil {
+	if instances.UpdateClusterMembers(log, clusterMembers, rebootAfter, provider); err != nil {
 		return maskAny(err)
 	}
 
@@ -43,7 +43,7 @@ func UpdateClusterMembers(log *logging.Logger, info ClusterInfo, rebootAfter boo
 }
 
 // UpdateClusterMembers updates /etc/cluster-members on all instances of the cluster
-func (instances ClusterInstanceList) UpdateClusterMembers(log *logging.Logger, clusterMembers ClusterMemberList, rebootAfter bool) error {
+func (instances ClusterInstanceList) UpdateClusterMembers(log *logging.Logger, clusterMembers ClusterMemberList, rebootAfter bool, provider CloudProvider) error {
 	// Now update all members in parallel
 	wg := sync.WaitGroup{}
 	errorChannel := make(chan error, len(instances))
@@ -55,7 +55,7 @@ func (instances ClusterInstanceList) UpdateClusterMembers(log *logging.Logger, c
 				errorChannel <- maskAny(err)
 			}
 			if rebootAfter {
-				if err := i.Reboot(log); err != nil {
+				if err := provider.RebootInstance(i); err != nil {
 					errorChannel <- maskAny(err)
 				}
 			}

--- a/providers/vultr/create.go
+++ b/providers/vultr/create.go
@@ -208,7 +208,7 @@ func (vp *vultrProvider) setupInstances(log *logging.Logger, instances []instanc
 				ClusterMembers: clusterMembers,
 				FleetMetadata:  instance.FleetMetadata,
 			}
-			if err := instance.ClusterInstance.InitialSetup(log, instance.CreateInstanceOptions, iso); err != nil {
+			if err := instance.ClusterInstance.InitialSetup(log, instance.CreateInstanceOptions, iso, vp); err != nil {
 				errors <- maskAny(err)
 				return
 			}

--- a/providers/vultr/instances.go
+++ b/providers/vultr/instances.go
@@ -62,11 +62,13 @@ func (dp *vultrProvider) clusterInstance(s lib.Server) providers.ClusterInstance
 		ipv6 = s.V6Networks[0].MainIP
 	}
 	info := providers.ClusterInstance{
-		Name:                 s.Name,
-		PrivateIpv4:          s.InternalIP,
-		PublicIpv4:           s.MainIP,
-		PublicIpv6:           ipv6,
-		PrivateClusterDevice: privateClusterDevice,
+		Name:             s.Name,
+		ClusterIP:        s.InternalIP,
+		PrivateIP:        s.InternalIP,
+		LoadBalancerIPv4: s.MainIP,
+		LoadBalancerIPv6: ipv6,
+		ClusterDevice:    privateClusterDevice,
+		OS:               providers.OSNameCoreOS,
 	}
 	return info
 }

--- a/providers/vultr/reboot.go
+++ b/providers/vultr/reboot.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vultr
+
+import (
+	"github.com/pulcy/quark/providers"
+)
+
+// Perform a reboot of the given instance
+func (vp *vultrProvider) RebootInstance(instance providers.ClusterInstance) error {
+	if _, err := instance.Exec(vp.Logger, "sudo shutdown -r now"); err != nil {
+		return maskAny(err)
+	}
+	return nil
+}

--- a/templates/scaleway-bootstrap.tmpl
+++ b/templates/scaleway-bootstrap.tmpl
@@ -115,7 +115,5 @@ EOETCD
 # Patch rootfs
 systemctl disable docker; systemctl enable docker
 
-# Reboot
+# Prepare for reboot
 sync
-shutdown -r now
-exit

--- a/templates/scaleway-bootstrap.tmpl
+++ b/templates/scaleway-bootstrap.tmpl
@@ -7,12 +7,15 @@ SCWPUBLIC=$(curl http://v4.myip.ninja)
 METADATA=`curl http://169.254.42.42/conf`
 MODEL=$(echo "$METADATA" | egrep COMMERCIAL_TYPE= | sed 's/COMMERCIAL_TYPE=//g')
 CLUSTERID=$(echo "$METADATA" | egrep TAGS_0= | sed 's/TAGS_0=//g')
-echo "COREOS_PRIVATE_IPV4="$SCWIP >>/etc/environment
+TINCIP=$(echo "$METADATA" | egrep TAGS_1= | sed 's/TAGS_1=//g')
+echo "HOST_PRIVATE_IPV4="$SCWIP >>/etc/environment
+echo "COREOS_PRIVATE_IPV4="$TINCIP >>/etc/environment
 echo "COREOS_PUBLIC_IPV4="$SCWPUBLIC >>/etc/environment
 echo "MODEL="$MODEL >>/etc/environment
 mkdir -p /etc/pulcy
-echo $CLUSTERID >>/etc/pulcy/cluster-id
+echo $CLUSTERID >/etc/pulcy/cluster-id
 chmod 0400 /etc/pulcy/cluster-id
+echo $TINCIP >/etc/pulcy/tinc-ip
 
 # Create machine-id
 rm -f /etc/.regen-machine-id
@@ -29,6 +32,8 @@ echo "core ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 # Link utilities
 cd /usr/bin && ln -s /bin/mkdir && ln -s /bin/rmdir
+cd /usr/sbin && ln -s /sbin/iptables-save && ln -s /sbin/iptables-restore && ln -s /sbin/iptables
+cd /usr/sbin && ln -s /sbin/ip6tables-save && ln -s /sbin/ip6tables-restore && ln -s /sbin/ip6tables
 
 # Fix hosts
 HOST=$(hostname)
@@ -37,7 +42,7 @@ echo "127.0.0.1 ${HOST}" >> /etc/hosts
 # Install packages
 apt-get -q update                   \
  && apt-get --force-yes -y -qq upgrade  \
- && apt-get --force-yes install -y -q tar \
+ && apt-get --force-yes install -y -q tar tinc \
  && apt-get clean
 
 # Install Fleet

--- a/templates/scaleway-tinc.tmpl
+++ b/templates/scaleway-tinc.tmpl
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+HOST=$(hostname)
+HOST=${HOST//-/_}
+HOSTIP=$(hostname  -I | awk '{print $1}')
+TINCIP=$(cat /etc/pulcy/tinc-ip)
+VPN=pulcy
+SSHOPTS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+
+sudo apt-get install tinc
+
+sudo mkdir -p /etc/tinc/${VPN}/hosts
+
+echo "Name = ${HOST}" | sudo tee /etc/tinc/${VPN}/tinc.conf
+echo "AddressFamily = ipv4" | sudo tee -a /etc/tinc/${VPN}/tinc.conf
+echo "Interface = tun0" | sudo tee -a /etc/tinc/${VPN}/tinc.conf
+
+echo "Address = ${HOSTIP}" | sudo tee /etc/tinc/${VPN}/hosts/${HOST}
+echo "Subnet = ${TINCIP}/24" | sudo tee -a /etc/tinc/${VPN}/hosts/${HOST}
+
+sudo tincd -n ${VPN} -K4096
+
+echo "#!/bin/sh" | sudo tee /etc/tinc/${VPN}/tinc-up
+echo "ifconfig \$INTERFACE ${TINCIP} netmask 255.255.255.0" | sudo tee -a /etc/tinc/${VPN}/tinc-up
+
+echo "#!/bin/sh" | sudo tee /etc/tinc/${VPN}/tinc-down
+echo "ifconfig \$INTERFACE down" | sudo tee -a /etc/tinc/${VPN}/tinc-down
+
+sudo chmod 755 /etc/tinc/${VPN}/tinc-*
+
+for line in $(cat /etc/pulcy/cluster-members); do
+    OTHERIP=$(echo $line | cut -d '=' -f 2)
+    if [ "${OTHERIP}" != "${HOSTIP}" ]; then
+        echo Copy to ${OTHERIP}
+        ssh $SSHOPTS core@${OTHERIP} mkdir -p /home/core/tinc/${VPN}/hosts/
+        rsync /etc/tinc/${VPN}/hosts/${HOST} core@${OTHERIP}:/home/core/tinc/${VPN}/hosts/
+        ssh $SSHOPTS core@${OTHERIP} sudo mkdir -p /etc/tinc/${VPN}/hosts/
+        ssh $SSHOPTS core@${OTHERIP} sudo mv /home/core/tinc/${VPN}/hosts/${HOST} /etc/tinc/${VPN}/hosts/
+    fi
+done

--- a/vendor/github.com/scaleway/scaleway-cli/README.md
+++ b/vendor/github.com/scaleway/scaleway-cli/README.md
@@ -316,14 +316,14 @@ Create a new server but do not start it.
 
 Options:
 
-  --bootscript=""       Assign a bootscript
-  --commercial-type=VC1 Create a server with specific commercial-type C1, VC1, C2[S|M|L]
-  -e, --env=""          Provide metadata tags passed to initrd (i.e., boot=resue INITRD_DEBUG=1)
-  -h, --help=false      Print usage
-  --ip-address=dynamic  Assign a reserved public IP, a 'dynamic' one or 'none'
-  --name=""             Assign a name
-  --tmp-ssh-key=false   Access your server without uploading your SSH key to your account
-  -v, --volume=""       Attach additional volume (i.e., 50G)
+  --bootscript=""        Assign a bootscript
+  --commercial-type=VC1S Create a server with specific commercial-type C1, VC1S, C2[S|M|L]
+  -e, --env=""           Provide metadata tags passed to initrd (i.e., boot=resue INITRD_DEBUG=1)
+  -h, --help=false       Print usage
+  --ip-address=dynamic   Assign a reserved public IP, a 'dynamic' one or 'none'
+  --name=""              Assign a name
+  --tmp-ssh-key=false    Access your server without uploading your SSH key to your account
+  -v, --volume=""        Attach additional volume (i.e., 50G)
 
 Examples:
 
@@ -691,21 +691,21 @@ Run a command in a new server.
 
 Options:
 
-  -a, --attach=false    Attach to serial console
-  --bootscript=""       Assign a bootscript
-  --commercial-type=VC1 Start a server with specific commercial-type C1, VC1, C2[SML]
-  -d, --detach=false    Run server in background and print server ID
-  -e, --env=""          Provide metadata tags passed to initrd (i.e., boot=rescue INITRD_DEBUG=1)
-  -g, --gateway=""      Use a SSH gateway
-  -h, --help=false      Print usage
-  --ip-address=""       Assign a reserved public IP, a 'dynamic' one or 'none' (default to 'none' if gateway specified, 'dynamic' otherwise)
-  --name=""             Assign a name
-  --rm=false            Automatically remove the server when it exits
-  --show-boot=false     Allows to show the boot
-  -T, --timeout=0       Set timeout value to seconds
-  --tmp-ssh-key=false   Access your server without uploading your SSH key to your account
-  -u, --userdata=""     Start a server with userdata predefined
-  -v, --volume=""       Attach additional volume (i.e., 50G)
+  -a, --attach=false     Attach to serial console
+  --bootscript=""        Assign a bootscript
+  --commercial-type=VC1S Start a server with specific commercial-type C1, VC1S, C2[SML]
+  -d, --detach=false     Run server in background and print server ID
+  -e, --env=""           Provide metadata tags passed to initrd (i.e., boot=rescue INITRD_DEBUG=1)
+  -g, --gateway=""       Use a SSH gateway
+  -h, --help=false       Print usage
+  --ip-address=""        Assign a reserved public IP, a 'dynamic' one or 'none' (default to 'none' if gateway specified, 'dynamic' otherwise)
+  --name=""              Assign a name
+  --rm=false             Automatically remove the server when it exits
+  --show-boot=false      Allows to show the boot
+  -T, --timeout=0        Set timeout value to seconds
+  --tmp-ssh-key=false    Access your server without uploading your SSH key to your account
+  -u, --userdata=""      Start a server with userdata predefined
+  -v, --volume=""        Attach additional volume (i.e., 50G)
 
 Examples:
 
@@ -1183,7 +1183,8 @@ $ scw inspect myserver | jq '.[0].public_ip.address'
 
 ### master (unreleased)
 
-* No entry
+* Fix bug when using SCW_COMMERCIAL_TYPE variable
+* Switch to VC1S
 
 View full [commits list](https://github.com/scaleway/scaleway-cli/compare/v1.8.1...master)
 

--- a/vendor/github.com/scaleway/scaleway-cli/examples/create-image-from-http.sh
+++ b/vendor/github.com/scaleway/scaleway-cli/examples/create-image-from-http.sh
@@ -17,7 +17,7 @@ NAME=$(basename "${URL}")
 SNAPSHOT_NAME=${NAME%.*}-$(date +%Y-%m-%d_%H:%M)
 IMAGE_NAME=${IMAGE_NAME:-$SNAPSHOT_NAME}
 IMAGE_BOOTSCRIPT=${IMAGE_BOOTSCRIPT:stable}
-SCW_COMMERCIAL_TYPE=${SCW_COMMERCIAL_TYPE:-VC1}
+SCW_COMMERCIAL_TYPE=${SCW_COMMERCIAL_TYPE:-VC1S}
 VOLUME_SIZE=${VOLUME_SIZE:-50GB}
 SCW_TARGET_ARCH=x86_64
 if [ "$SCW_COMMERCIAL_TYPE" = "C1" ]; then
@@ -30,7 +30,7 @@ echo "[+] Target name: ${NAME}"
 
 
 echo "[+] Creating new server in rescue mode with a secondary volume..."
-SERVER=$(SCW_TARGET_ARCH="$SCW_TARGET_ARCH" SCW_COMMERCIAL_TYPE="$SCW_COMMERCIAL_TYPE" scw run -d --env="AUTHORIZED_KEY=${KEY} boot=none INITRD_DROPBEAR=1" --name="image-writer-${NAME}" "${VOLUME_SIZE}")
+SERVER=$(SCW_TARGET_ARCH="$SCW_TARGET_ARCH" scw run --commercial-type="${SCW_COMMERCIAL_TYPE}" -d --env="AUTHORIZED_KEY=${KEY} boot=none INITRD_DROPBEAR=1" --name="image-writer-${NAME}" "${VOLUME_SIZE}")
 echo "[+] Server created: ${SERVER}"
 
 

--- a/vendor/github.com/scaleway/scaleway-cli/pkg/api/api.go
+++ b/vendor/github.com/scaleway/scaleway-cli/pkg/api/api.go
@@ -511,7 +511,7 @@ type ScalewayServer struct {
 	// Organization is the owner of the server
 	Organization string `json:"organization,omitempty"`
 
-	// CommercialType is the commercial type of the server (i.e: C1, C2[SML], VC1)
+	// CommercialType is the commercial type of the server (i.e: C1, C2[SML], VC1S)
 	CommercialType string `json:"commercial_type,omitempty"`
 
 	// Location of the server
@@ -568,7 +568,7 @@ type ScalewayServerDefinition struct {
 	// Organization is the owner of the server
 	Organization string `json:"organization"`
 
-	// CommercialType is the commercial type of the server (i.e: C1, C2[SML], VC1)
+	// CommercialType is the commercial type of the server (i.e: C1, C2[SML], VC1S)
 	CommercialType string `json:"commercial_type"`
 
 	PublicIP string `json:"public_ip,omitempty"`

--- a/vendor/github.com/scaleway/scaleway-cli/pkg/api/helpers.go
+++ b/vendor/github.com/scaleway/scaleway-cli/pkg/api/helpers.go
@@ -300,7 +300,7 @@ type ConfigCreateServer struct {
 // CreateServer creates a server using API based on typical server fields
 func CreateServer(api *ScalewayAPI, c *ConfigCreateServer) (string, error) {
 	commercialType := os.Getenv("SCW_COMMERCIAL_TYPE")
-	if commercialType != "" {
+	if commercialType == "" {
 		commercialType = c.CommercialType
 	}
 

--- a/vendor/github.com/scaleway/scaleway-cli/pkg/cli/cmd_create.go
+++ b/vendor/github.com/scaleway/scaleway-cli/pkg/cli/cmd_create.go
@@ -31,7 +31,7 @@ func init() {
 	cmdCreate.Flag.StringVar(&createEnv, []string{"e", "-env"}, "", "Provide metadata tags passed to initrd (i.e., boot=resue INITRD_DEBUG=1)")
 	cmdCreate.Flag.StringVar(&createVolume, []string{"v", "-volume"}, "", "Attach additional volume (i.e., 50G)")
 	cmdCreate.Flag.StringVar(&createIPAddress, []string{"-ip-address"}, "dynamic", "Assign a reserved public IP, a 'dynamic' one or 'none'")
-	cmdCreate.Flag.StringVar(&createCommercialType, []string{"-commercial-type"}, "VC1", "Create a server with specific commercial-type C1, VC1, C2[S|M|L]")
+	cmdCreate.Flag.StringVar(&createCommercialType, []string{"-commercial-type"}, "VC1S", "Create a server with specific commercial-type C1, VC1S, C2[S|M|L]")
 	cmdCreate.Flag.BoolVar(&createHelp, []string{"h", "-help"}, false, "Print usage")
 	cmdCreate.Flag.BoolVar(&createTmpSSHKey, []string{"-tmp-ssh-key"}, false, "Access your server without uploading your SSH key to your account")
 }

--- a/vendor/github.com/scaleway/scaleway-cli/pkg/cli/cmd_run.go
+++ b/vendor/github.com/scaleway/scaleway-cli/pkg/cli/cmd_run.go
@@ -45,7 +45,7 @@ func init() {
 	cmdRun.Flag.BoolVar(&runDetachFlag, []string{"d", "-detach"}, false, "Run server in background and print server ID")
 	cmdRun.Flag.StringVar(&runGateway, []string{"g", "-gateway"}, "", "Use a SSH gateway")
 	cmdRun.Flag.StringVar(&runUserdatas, []string{"u", "-userdata"}, "", "Start a server with userdata predefined")
-	cmdRun.Flag.StringVar(&runCommercialType, []string{"-commercial-type"}, "VC1", "Start a server with specific commercial-type C1, VC1, C2[SML]")
+	cmdRun.Flag.StringVar(&runCommercialType, []string{"-commercial-type"}, "VC1S", "Start a server with specific commercial-type C1, VC1S, C2[SML]")
 	cmdRun.Flag.BoolVar(&runAutoRemove, []string{"-rm"}, false, "Automatically remove the server when it exits")
 	cmdRun.Flag.BoolVar(&runTmpSSHKey, []string{"-tmp-ssh-key"}, false, "Access your server without uploading your SSH key to your account")
 	cmdRun.Flag.BoolVar(&runShowBoot, []string{"-show-boot"}, false, "Allows to show the boot")

--- a/vendor/github.com/scaleway/scaleway-cli/pkg/commands/create_test.go
+++ b/vendor/github.com/scaleway/scaleway-cli/pkg/commands/create_test.go
@@ -63,7 +63,7 @@ func TestRunCreate_realAPI(t *testing.T) {
 			args := CreateArgs{
 				Name:           "unittest-create-standard",
 				Image:          "ubuntu-wily",
-				CommercialType: "VC1",
+				CommercialType: "VC1S",
 			}
 
 			scopedCtx, scopedStdout, scopedStderr := getScopedCtx(ctx)

--- a/vendor/github.com/scaleway/scaleway-cli/pkg/commands/run_test.go
+++ b/vendor/github.com/scaleway/scaleway-cli/pkg/commands/run_test.go
@@ -8,7 +8,7 @@ func ExampleRun() {
 	ctx := testCommandContext()
 	args := RunArgs{
 		Image:          "ubuntu-trusty",
-		CommercialType: "VC1",
+		CommercialType: "VC1S",
 	}
 	Run(ctx, args)
 }
@@ -23,7 +23,7 @@ func ExampleRun_complex() {
 		Gateway:        "my-gateway",
 		Image:          "ubuntu-trusty",
 		Name:           "my-test-server",
-		CommercialType: "VC1",
+		CommercialType: "VC1S",
 		Tags:           []string{"testing", "fake"},
 		Volumes:        []string{"50G", "1G"},
 	}

--- a/vendor/github.com/spf13/cobra/bash_completions_test.go
+++ b/vendor/github.com/spf13/cobra/bash_completions_test.go
@@ -25,7 +25,7 @@ func check(t *testing.T, found, expected string) {
 
 // World worst custom function, just keep telling you to enter hello!
 const (
-	bash_completion_func = `__custom_func() {
+	bashCompletionFunc = `__custom_func() {
 COMPREPLY=( "hello" )
 }
 `
@@ -37,7 +37,7 @@ func TestBashCompletions(t *testing.T) {
 	c.AddCommand(cmdEcho, cmdPrint, cmdDeprecated, cmdColon)
 
 	// custom completion function
-	c.BashCompletionFunction = bash_completion_func
+	c.BashCompletionFunction = bashCompletionFunc
 
 	// required flag
 	c.MarkFlagRequired("introot")

--- a/vendor/github.com/spf13/cobra/cobra.go
+++ b/vendor/github.com/spf13/cobra/cobra.go
@@ -26,7 +26,7 @@ import (
 	"unicode"
 )
 
-var templateFuncs template.FuncMap = template.FuncMap{
+var templateFuncs = template.FuncMap{
 	"trim":               strings.TrimSpace,
 	"trimRightSpace":     trimRightSpace,
 	"appendIfNotPresent": appendIfNotPresent,
@@ -39,7 +39,7 @@ var initializers []func()
 
 // automatic prefix matching can be a dangerous thing to automatically enable in CLI tools.
 // Set this to true to enable it
-var EnablePrefixMatching bool = false
+var EnablePrefixMatching = false
 
 //AddTemplateFunc adds a template function that's available to Usage and Help
 //template generation.

--- a/vendor/github.com/spf13/cobra/cobra/cmd/helpers.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/helpers.go
@@ -196,7 +196,7 @@ func isEmpty(path string) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		list, err := f.Readdir(-1)
+		list, _ := f.Readdir(-1)
 		// f.Close() - see bug fix above
 		return len(list) == 0, nil
 	}

--- a/vendor/github.com/spf13/cobra/cobra/cmd/root.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/root.go
@@ -24,7 +24,7 @@ import (
 var cfgFile string
 var userLicense string
 
-// This represents the base command when called without any subcommands
+// RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "cobra",
 	Short: "A generator for Cobra based Applications",

--- a/vendor/github.com/spf13/cobra/cobra_test.go
+++ b/vendor/github.com/spf13/cobra/cobra_test.go
@@ -454,10 +454,10 @@ func TestGrandChildSameName(t *testing.T) {
 
 func TestUsage(t *testing.T) {
 	x := fullSetupTest("help")
-	checkResultContains(t, x, cmdRootWithRun.Use + " [flags]")
+	checkResultContains(t, x, cmdRootWithRun.Use+" [flags]")
 	x = fullSetupTest("help customflags")
 	checkResultContains(t, x, cmdCustomFlags.Use)
-	checkResultOmits(t, x, cmdCustomFlags.Use + " [flags]")
+	checkResultOmits(t, x, cmdCustomFlags.Use+" [flags]")
 }
 
 func TestFlagLong(t *testing.T) {
@@ -752,7 +752,7 @@ func TestVisitParents(t *testing.T) {
 }
 
 func TestRunnableRootCommandNilInput(t *testing.T) {
-	empty_arg := make([]string, 0)
+	var emptyArg []string
 	c := initializeWithRootCmd()
 
 	buf := new(bytes.Buffer)
@@ -760,7 +760,7 @@ func TestRunnableRootCommandNilInput(t *testing.T) {
 	c.SetOutput(buf)
 	cmdEcho.AddCommand(cmdTimes)
 	c.AddCommand(cmdPrint, cmdEcho)
-	c.SetArgs(empty_arg)
+	c.SetArgs(emptyArg)
 
 	err := c.Execute()
 	if err != nil {
@@ -863,7 +863,7 @@ func TestFlagAccess(t *testing.T) {
 }
 
 func TestNoNRunnableRootCommandNilInput(t *testing.T) {
-	args := make([]string, 0)
+	var args []string
 	c := initialize()
 
 	buf := new(bytes.Buffer)

--- a/vendor/github.com/spf13/cobra/command.go
+++ b/vendor/github.com/spf13/cobra/command.go
@@ -132,9 +132,8 @@ func (c *Command) getOut(def io.Writer) io.Writer {
 
 	if c.HasParent() {
 		return c.parent.Out()
-	} else {
-		return def
 	}
+	return def
 }
 
 func (c *Command) Out() io.Writer {
@@ -194,14 +193,13 @@ func (c *Command) UsageFunc() (f func(*Command) error) {
 
 	if c.HasParent() {
 		return c.parent.UsageFunc()
-	} else {
-		return func(c *Command) error {
-			err := tmpl(c.Out(), c.UsageTemplate(), c)
-			if err != nil {
-				fmt.Print(err)
-			}
-			return err
+	}
+	return func(c *Command) error {
+		err := tmpl(c.Out(), c.UsageTemplate(), c)
+		if err != nil {
+			fmt.Print(err)
 		}
+		return err
 	}
 }
 
@@ -223,35 +221,32 @@ func (c *Command) HelpFunc() func(*Command, []string) {
 	}
 }
 
-var minUsagePadding int = 25
+var minUsagePadding = 25
 
 func (c *Command) UsagePadding() int {
 	if c.parent == nil || minUsagePadding > c.parent.commandsMaxUseLen {
 		return minUsagePadding
-	} else {
-		return c.parent.commandsMaxUseLen
 	}
+	return c.parent.commandsMaxUseLen
 }
 
-var minCommandPathPadding int = 11
+var minCommandPathPadding = 11
 
 //
 func (c *Command) CommandPathPadding() int {
 	if c.parent == nil || minCommandPathPadding > c.parent.commandsMaxCommandPathLen {
 		return minCommandPathPadding
-	} else {
-		return c.parent.commandsMaxCommandPathLen
 	}
+	return c.parent.commandsMaxCommandPathLen
 }
 
-var minNamePadding int = 11
+var minNamePadding = 11
 
 func (c *Command) NamePadding() int {
 	if c.parent == nil || minNamePadding > c.parent.commandsMaxNameLen {
 		return minNamePadding
-	} else {
-		return c.parent.commandsMaxNameLen
 	}
+	return c.parent.commandsMaxNameLen
 }
 
 func (c *Command) UsageTemplate() string {
@@ -261,8 +256,8 @@ func (c *Command) UsageTemplate() string {
 
 	if c.HasParent() {
 		return c.parent.UsageTemplate()
-	} else {
-		return `Usage:{{if .Runnable}}
+	}
+	return `Usage:{{if .Runnable}}
   {{if .HasFlags}}{{appendIfNotPresent .UseLine "[flags]"}}{{else}}{{.UseLine}}{{end}}{{end}}{{if .HasSubCommands}}
   {{ .CommandPath}} [command]{{end}}{{if gt .Aliases 0}}
 
@@ -287,7 +282,6 @@ Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
 
 Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
 `
-	}
 }
 
 func (c *Command) HelpTemplate() string {
@@ -297,11 +291,10 @@ func (c *Command) HelpTemplate() string {
 
 	if c.HasParent() {
 		return c.parent.HelpTemplate()
-	} else {
-		return `{{with or .Long .Short }}{{. | trim}}
+	}
+	return `{{with or .Long .Short }}{{. | trim}}
 
 {{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
-	}
 }
 
 // Really only used when casting a command to a commander
@@ -603,9 +596,8 @@ func (c *Command) errorMsgFromParse() string {
 
 	if len(x) > 0 {
 		return x[0]
-	} else {
-		return ""
 	}
+	return ""
 }
 
 // Call execute to use the args (os.Args[1:] by default)
@@ -786,18 +778,18 @@ main:
 	}
 }
 
-// Convenience method to Print to the defined output
+// Print is a convenience method to Print to the defined output
 func (c *Command) Print(i ...interface{}) {
 	fmt.Fprint(c.Out(), i...)
 }
 
-// Convenience method to Println to the defined output
+// Println is a convenience method to Println to the defined output
 func (c *Command) Println(i ...interface{}) {
 	str := fmt.Sprintln(i...)
 	c.Print(str)
 }
 
-// Convenience method to Printf to the defined output
+// Printf is a convenience method to Printf to the defined output
 func (c *Command) Printf(format string, i ...interface{}) {
 	str := fmt.Sprintf(format, i...)
 	c.Print(str)
@@ -908,7 +900,7 @@ func (c *Command) Name() string {
 	return name
 }
 
-// Determine if a given string is an alias of the command.
+// HasAlias determines if a given string is an alias of the command.
 func (c *Command) HasAlias(s string) bool {
 	for _, a := range c.Aliases {
 		if a == s {
@@ -926,12 +918,12 @@ func (c *Command) HasExample() bool {
 	return len(c.Example) > 0
 }
 
-// Determine if the command is itself runnable
+// Runnable determines if the command is itself runnable
 func (c *Command) Runnable() bool {
 	return c.Run != nil || c.RunE != nil
 }
 
-// Determine if the command has children commands
+// HasSubCommands determines if the command has children commands
 func (c *Command) HasSubCommands() bool {
 	return len(c.commands) > 0
 }
@@ -1123,7 +1115,7 @@ func (c *Command) HasInheritedFlags() bool {
 	return c.InheritedFlags().HasFlags()
 }
 
-// Climbs up the command tree looking for matching flag
+// Flag climbs up the command tree looking for matching flag
 func (c *Command) Flag(name string) (flag *flag.Flag) {
 	flag = c.Flags().Lookup(name)
 
@@ -1146,13 +1138,14 @@ func (c *Command) persistentFlag(name string) (flag *flag.Flag) {
 	return
 }
 
-// Parses persistent flag tree & local flags
+// ParseFlags parses persistent flag tree & local flags
 func (c *Command) ParseFlags(args []string) (err error) {
 	c.mergePersistentFlags()
 	err = c.Flags().Parse(args)
 	return
 }
 
+// Parent returns a commands parent command
 func (c *Command) Parent() *Command {
 	return c.parent
 }

--- a/vendor/github.com/spf13/cobra/command_notwin.go
+++ b/vendor/github.com/spf13/cobra/command_notwin.go
@@ -2,4 +2,4 @@
 
 package cobra
 
-var preExecHookFn func(*Command) = nil
+var preExecHookFn func(*Command)

--- a/vendor/github.com/spf13/cobra/doc/man_docs_test.go
+++ b/vendor/github.com/spf13/cobra/doc/man_docs_test.go
@@ -149,9 +149,8 @@ func AssertNextLineEquals(scanner *bufio.Scanner, expectedLine string) error {
 		line := scanner.Text()
 		if line == expectedLine {
 			return nil
-		} else {
-			return fmt.Errorf("AssertNextLineEquals: got %#v, not %#v", line, expectedLine)
 		}
+		return fmt.Errorf("AssertNextLineEquals: got %#v, not %#v", line, expectedLine)
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/vendor/golang.org/x/net/ipv4/sockopt_asmreq_unix.go
+++ b/vendor/golang.org/x/net/ipv4/sockopt_asmreq_unix.go
@@ -24,7 +24,7 @@ func setsockoptIPMreq(fd, name int, ifi *net.Interface, grp net.IP) error {
 
 func getsockoptInterface(fd, name int) (*net.Interface, error) {
 	var b [4]byte
-	l := sysSockoptLen(4)
+	l := uint32(4)
 	if err := getsockopt(fd, iana.ProtocolIP, name, unsafe.Pointer(&b[0]), &l); err != nil {
 		return nil, os.NewSyscallError("getsockopt", err)
 	}
@@ -42,5 +42,5 @@ func setsockoptInterface(fd, name int, ifi *net.Interface) error {
 	}
 	var b [4]byte
 	copy(b[:], ip)
-	return os.NewSyscallError("setsockopt", setsockopt(fd, iana.ProtocolIP, name, unsafe.Pointer(&b[0]), sysSockoptLen(4)))
+	return os.NewSyscallError("setsockopt", setsockopt(fd, iana.ProtocolIP, name, unsafe.Pointer(&b[0]), uint32(4)))
 }

--- a/vendor/golang.org/x/net/ipv4/sockopt_asmreqn_unix.go
+++ b/vendor/golang.org/x/net/ipv4/sockopt_asmreqn_unix.go
@@ -16,7 +16,7 @@ import (
 
 func getsockoptIPMreqn(fd, name int) (*net.Interface, error) {
 	var mreqn sysIPMreqn
-	l := sysSockoptLen(sysSizeofIPMreqn)
+	l := uint32(sysSizeofIPMreqn)
 	if err := getsockopt(fd, iana.ProtocolIP, name, unsafe.Pointer(&mreqn), &l); err != nil {
 		return nil, os.NewSyscallError("getsockopt", err)
 	}

--- a/vendor/golang.org/x/net/ipv4/sockopt_ssmreq_unix.go
+++ b/vendor/golang.org/x/net/ipv4/sockopt_ssmreq_unix.go
@@ -23,7 +23,7 @@ func setsockoptGroupReq(fd, name int, ifi *net.Interface, grp net.IP) error {
 	}
 	gr.setGroup(grp)
 	var p unsafe.Pointer
-	var l sysSockoptLen
+	var l uint32
 	if freebsd32o64 {
 		var d [sysSizeofGroupReq + 4]byte
 		s := (*[sysSizeofGroupReq]byte)(unsafe.Pointer(&gr))
@@ -45,7 +45,7 @@ func setsockoptGroupSourceReq(fd, name int, ifi *net.Interface, grp, src net.IP)
 	}
 	gsr.setSourceGroup(grp, src)
 	var p unsafe.Pointer
-	var l sysSockoptLen
+	var l uint32
 	if freebsd32o64 {
 		var d [sysSizeofGroupSourceReq + 4]byte
 		s := (*[sysSizeofGroupSourceReq]byte)(unsafe.Pointer(&gsr))

--- a/vendor/golang.org/x/net/ipv4/sockopt_unix.go
+++ b/vendor/golang.org/x/net/ipv4/sockopt_unix.go
@@ -21,10 +21,10 @@ func getInt(fd int, opt *sockOpt) (int, error) {
 	var i int32
 	var b byte
 	p := unsafe.Pointer(&i)
-	l := sysSockoptLen(4)
+	l := uint32(4)
 	if opt.typ == ssoTypeByte {
 		p = unsafe.Pointer(&b)
-		l = sysSockoptLen(1)
+		l = 1
 	}
 	if err := getsockopt(fd, iana.ProtocolIP, opt.name, p, &l); err != nil {
 		return 0, os.NewSyscallError("getsockopt", err)
@@ -42,11 +42,11 @@ func setInt(fd int, opt *sockOpt, v int) error {
 	i := int32(v)
 	var b byte
 	p := unsafe.Pointer(&i)
-	l := sysSockoptLen(4)
+	l := uint32(4)
 	if opt.typ == ssoTypeByte {
 		b = byte(v)
 		p = unsafe.Pointer(&b)
-		l = sysSockoptLen(1)
+		l = 1
 	}
 	return os.NewSyscallError("setsockopt", setsockopt(fd, iana.ProtocolIP, opt.name, p, l))
 }
@@ -84,7 +84,7 @@ func getICMPFilter(fd int, opt *sockOpt) (*ICMPFilter, error) {
 		return nil, errOpNoSupport
 	}
 	var f ICMPFilter
-	l := sysSockoptLen(sysSizeofICMPFilter)
+	l := uint32(sysSizeofICMPFilter)
 	if err := getsockopt(fd, iana.ProtocolReserved, opt.name, unsafe.Pointer(&f.sysICMPFilter), &l); err != nil {
 		return nil, os.NewSyscallError("getsockopt", err)
 	}

--- a/vendor/golang.org/x/net/ipv4/sys_bsd.go
+++ b/vendor/golang.org/x/net/ipv4/sys_bsd.go
@@ -11,8 +11,6 @@ import (
 	"syscall"
 )
 
-type sysSockoptLen int32
-
 var (
 	ctlOpts = [ctlMax]ctlOpt{
 		ctlTTL:       {sysIP_RECVTTL, 1, marshalTTL, parseTTL},

--- a/vendor/golang.org/x/net/ipv4/sys_darwin.go
+++ b/vendor/golang.org/x/net/ipv4/sys_darwin.go
@@ -10,8 +10,6 @@ import (
 	"unsafe"
 )
 
-type sysSockoptLen int32
-
 var (
 	ctlOpts = [ctlMax]ctlOpt{
 		ctlTTL:       {sysIP_RECVTTL, 1, marshalTTL, parseTTL},

--- a/vendor/golang.org/x/net/ipv4/sys_freebsd.go
+++ b/vendor/golang.org/x/net/ipv4/sys_freebsd.go
@@ -12,8 +12,6 @@ import (
 	"unsafe"
 )
 
-type sysSockoptLen int32
-
 var (
 	ctlOpts = [ctlMax]ctlOpt{
 		ctlTTL:       {sysIP_RECVTTL, 1, marshalTTL, parseTTL},

--- a/vendor/golang.org/x/net/ipv4/sys_linux.go
+++ b/vendor/golang.org/x/net/ipv4/sys_linux.go
@@ -10,8 +10,6 @@ import (
 	"unsafe"
 )
 
-type sysSockoptLen int32
-
 var (
 	ctlOpts = [ctlMax]ctlOpt{
 		ctlTTL:        {sysIP_TTL, 1, marshalTTL, parseTTL},

--- a/vendor/golang.org/x/net/ipv4/sys_openbsd.go
+++ b/vendor/golang.org/x/net/ipv4/sys_openbsd.go
@@ -9,8 +9,6 @@ import (
 	"syscall"
 )
 
-type sysSockoptLen int32
-
 var (
 	ctlOpts = [ctlMax]ctlOpt{
 		ctlTTL:       {sysIP_RECVTTL, 1, marshalTTL, parseTTL},

--- a/vendor/golang.org/x/net/ipv4/sys_stub.go
+++ b/vendor/golang.org/x/net/ipv4/sys_stub.go
@@ -6,8 +6,6 @@
 
 package ipv4
 
-type sysSockoptLen int32
-
 var (
 	ctlOpts = [ctlMax]ctlOpt{}
 

--- a/vendor/golang.org/x/net/ipv4/syscall_linux_386.go
+++ b/vendor/golang.org/x/net/ipv4/syscall_linux_386.go
@@ -16,14 +16,14 @@ const (
 
 func socketcall(call int, a0, a1, a2, a3, a4, a5 uintptr) (int, syscall.Errno)
 
-func getsockopt(fd, level, name int, v unsafe.Pointer, l *sysSockoptLen) error {
+func getsockopt(fd, level, name int, v unsafe.Pointer, l *uint32) error {
 	if _, errno := socketcall(sysGETSOCKOPT, uintptr(fd), uintptr(level), uintptr(name), uintptr(v), uintptr(unsafe.Pointer(l)), 0); errno != 0 {
 		return error(errno)
 	}
 	return nil
 }
 
-func setsockopt(fd, level, name int, v unsafe.Pointer, l sysSockoptLen) error {
+func setsockopt(fd, level, name int, v unsafe.Pointer, l uint32) error {
 	if _, errno := socketcall(sysSETSOCKOPT, uintptr(fd), uintptr(level), uintptr(name), uintptr(v), uintptr(l), 0); errno != 0 {
 		return error(errno)
 	}

--- a/vendor/golang.org/x/net/ipv4/syscall_unix.go
+++ b/vendor/golang.org/x/net/ipv4/syscall_unix.go
@@ -11,14 +11,14 @@ import (
 	"unsafe"
 )
 
-func getsockopt(fd, level, name int, v unsafe.Pointer, l *sysSockoptLen) error {
+func getsockopt(fd, level, name int, v unsafe.Pointer, l *uint32) error {
 	if _, _, errno := syscall.Syscall6(syscall.SYS_GETSOCKOPT, uintptr(fd), uintptr(level), uintptr(name), uintptr(v), uintptr(unsafe.Pointer(l)), 0); errno != 0 {
 		return error(errno)
 	}
 	return nil
 }
 
-func setsockopt(fd, level, name int, v unsafe.Pointer, l sysSockoptLen) error {
+func setsockopt(fd, level, name int, v unsafe.Pointer, l uint32) error {
 	if _, _, errno := syscall.Syscall6(syscall.SYS_SETSOCKOPT, uintptr(fd), uintptr(level), uintptr(name), uintptr(v), uintptr(l), 0); errno != 0 {
 		return error(errno)
 	}

--- a/vendor/golang.org/x/net/ipv6/sockopt_ssmreq_unix.go
+++ b/vendor/golang.org/x/net/ipv6/sockopt_ssmreq_unix.go
@@ -21,7 +21,7 @@ func setsockoptGroupReq(fd int, opt *sockOpt, ifi *net.Interface, grp net.IP) er
 	}
 	gr.setGroup(grp)
 	var p unsafe.Pointer
-	var l sysSockoptLen
+	var l uint32
 	if freebsd32o64 {
 		var d [sysSizeofGroupReq + 4]byte
 		s := (*[sysSizeofGroupReq]byte)(unsafe.Pointer(&gr))
@@ -43,7 +43,7 @@ func setsockoptGroupSourceReq(fd int, opt *sockOpt, ifi *net.Interface, grp, src
 	}
 	gsr.setSourceGroup(grp, src)
 	var p unsafe.Pointer
-	var l sysSockoptLen
+	var l uint32
 	if freebsd32o64 {
 		var d [sysSizeofGroupSourceReq + 4]byte
 		s := (*[sysSizeofGroupSourceReq]byte)(unsafe.Pointer(&gsr))

--- a/vendor/golang.org/x/net/ipv6/sockopt_unix.go
+++ b/vendor/golang.org/x/net/ipv6/sockopt_unix.go
@@ -17,7 +17,7 @@ func getInt(fd int, opt *sockOpt) (int, error) {
 		return 0, errOpNoSupport
 	}
 	var i int32
-	l := sysSockoptLen(4)
+	l := uint32(4)
 	if err := getsockopt(fd, opt.level, opt.name, unsafe.Pointer(&i), &l); err != nil {
 		return 0, os.NewSyscallError("getsockopt", err)
 	}
@@ -29,7 +29,7 @@ func setInt(fd int, opt *sockOpt, v int) error {
 		return errOpNoSupport
 	}
 	i := int32(v)
-	return os.NewSyscallError("setsockopt", setsockopt(fd, opt.level, opt.name, unsafe.Pointer(&i), sysSockoptLen(4)))
+	return os.NewSyscallError("setsockopt", setsockopt(fd, opt.level, opt.name, unsafe.Pointer(&i), 4))
 }
 
 func getInterface(fd int, opt *sockOpt) (*net.Interface, error) {
@@ -37,7 +37,7 @@ func getInterface(fd int, opt *sockOpt) (*net.Interface, error) {
 		return nil, errOpNoSupport
 	}
 	var i int32
-	l := sysSockoptLen(4)
+	l := uint32(4)
 	if err := getsockopt(fd, opt.level, opt.name, unsafe.Pointer(&i), &l); err != nil {
 		return nil, os.NewSyscallError("getsockopt", err)
 	}
@@ -59,7 +59,7 @@ func setInterface(fd int, opt *sockOpt, ifi *net.Interface) error {
 	if ifi != nil {
 		i = int32(ifi.Index)
 	}
-	return os.NewSyscallError("setsockopt", setsockopt(fd, opt.level, opt.name, unsafe.Pointer(&i), sysSockoptLen(4)))
+	return os.NewSyscallError("setsockopt", setsockopt(fd, opt.level, opt.name, unsafe.Pointer(&i), 4))
 }
 
 func getICMPFilter(fd int, opt *sockOpt) (*ICMPFilter, error) {
@@ -67,7 +67,7 @@ func getICMPFilter(fd int, opt *sockOpt) (*ICMPFilter, error) {
 		return nil, errOpNoSupport
 	}
 	var f ICMPFilter
-	l := sysSockoptLen(sysSizeofICMPv6Filter)
+	l := uint32(sysSizeofICMPv6Filter)
 	if err := getsockopt(fd, opt.level, opt.name, unsafe.Pointer(&f.sysICMPv6Filter), &l); err != nil {
 		return nil, os.NewSyscallError("getsockopt", err)
 	}
@@ -86,7 +86,7 @@ func getMTUInfo(fd int, opt *sockOpt) (*net.Interface, int, error) {
 		return nil, 0, errOpNoSupport
 	}
 	var mi sysIPv6Mtuinfo
-	l := sysSockoptLen(sysSizeofIPv6Mtuinfo)
+	l := uint32(sysSizeofIPv6Mtuinfo)
 	if err := getsockopt(fd, opt.level, opt.name, unsafe.Pointer(&mi), &l); err != nil {
 		return nil, 0, os.NewSyscallError("getsockopt", err)
 	}

--- a/vendor/golang.org/x/net/ipv6/sys_bsd.go
+++ b/vendor/golang.org/x/net/ipv6/sys_bsd.go
@@ -13,8 +13,6 @@ import (
 	"golang.org/x/net/internal/iana"
 )
 
-type sysSockoptLen int32
-
 var (
 	ctlOpts = [ctlMax]ctlOpt{
 		ctlTrafficClass: {sysIPV6_TCLASS, 4, marshalTrafficClass, parseTrafficClass},

--- a/vendor/golang.org/x/net/ipv6/sys_darwin.go
+++ b/vendor/golang.org/x/net/ipv6/sys_darwin.go
@@ -12,8 +12,6 @@ import (
 	"golang.org/x/net/internal/iana"
 )
 
-type sysSockoptLen int32
-
 var (
 	ctlOpts = [ctlMax]ctlOpt{
 		ctlHopLimit:   {sysIPV6_2292HOPLIMIT, 4, marshal2292HopLimit, parseHopLimit},

--- a/vendor/golang.org/x/net/ipv6/sys_freebsd.go
+++ b/vendor/golang.org/x/net/ipv6/sys_freebsd.go
@@ -14,8 +14,6 @@ import (
 	"golang.org/x/net/internal/iana"
 )
 
-type sysSockoptLen int32
-
 var (
 	ctlOpts = [ctlMax]ctlOpt{
 		ctlTrafficClass: {sysIPV6_TCLASS, 4, marshalTrafficClass, parseTrafficClass},

--- a/vendor/golang.org/x/net/ipv6/sys_linux.go
+++ b/vendor/golang.org/x/net/ipv6/sys_linux.go
@@ -12,8 +12,6 @@ import (
 	"golang.org/x/net/internal/iana"
 )
 
-type sysSockoptLen int32
-
 var (
 	ctlOpts = [ctlMax]ctlOpt{
 		ctlTrafficClass: {sysIPV6_TCLASS, 4, marshalTrafficClass, parseTrafficClass},

--- a/vendor/golang.org/x/net/ipv6/sys_stub.go
+++ b/vendor/golang.org/x/net/ipv6/sys_stub.go
@@ -6,8 +6,6 @@
 
 package ipv6
 
-type sysSockoptLen int32
-
 var (
 	ctlOpts = [ctlMax]ctlOpt{}
 

--- a/vendor/golang.org/x/net/ipv6/syscall_linux_386.go
+++ b/vendor/golang.org/x/net/ipv6/syscall_linux_386.go
@@ -16,14 +16,14 @@ const (
 
 func socketcall(call int, a0, a1, a2, a3, a4, a5 uintptr) (int, syscall.Errno)
 
-func getsockopt(fd, level, name int, v unsafe.Pointer, l *sysSockoptLen) error {
+func getsockopt(fd, level, name int, v unsafe.Pointer, l *uint32) error {
 	if _, errno := socketcall(sysGETSOCKOPT, uintptr(fd), uintptr(level), uintptr(name), uintptr(v), uintptr(unsafe.Pointer(l)), 0); errno != 0 {
 		return error(errno)
 	}
 	return nil
 }
 
-func setsockopt(fd, level, name int, v unsafe.Pointer, l sysSockoptLen) error {
+func setsockopt(fd, level, name int, v unsafe.Pointer, l uint32) error {
 	if _, errno := socketcall(sysSETSOCKOPT, uintptr(fd), uintptr(level), uintptr(name), uintptr(v), uintptr(l), 0); errno != 0 {
 		return error(errno)
 	}

--- a/vendor/golang.org/x/net/ipv6/syscall_unix.go
+++ b/vendor/golang.org/x/net/ipv6/syscall_unix.go
@@ -11,14 +11,14 @@ import (
 	"unsafe"
 )
 
-func getsockopt(fd, level, name int, v unsafe.Pointer, l *sysSockoptLen) error {
+func getsockopt(fd, level, name int, v unsafe.Pointer, l *uint32) error {
 	if _, _, errno := syscall.Syscall6(syscall.SYS_GETSOCKOPT, uintptr(fd), uintptr(level), uintptr(name), uintptr(v), uintptr(unsafe.Pointer(l)), 0); errno != 0 {
 		return error(errno)
 	}
 	return nil
 }
 
-func setsockopt(fd, level, name int, v unsafe.Pointer, l sysSockoptLen) error {
+func setsockopt(fd, level, name int, v unsafe.Pointer, l uint32) error {
 	if _, _, errno := syscall.Syscall6(syscall.SYS_SETSOCKOPT, uintptr(fd), uintptr(level), uintptr(name), uintptr(v), uintptr(l), 0); errno != 0 {
 		return error(errno)
 	}


### PR DESCRIPTION
This PR adds tinc-vpn support in the Scaleway provider.
This serves 2 purposes.
1 - We can choose the tinc IP addresses, so ETCD has something stable to work with 
2 - We have secure private communications 
