### PR TITLE
Added `cluster update` support (for scaleway instances)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BIN := $(BINDIR)/$(PROJECT)
 GOBINDATA := $(GOBUILDDIR)/bin/go-bindata
 
 GOPATH := $(GOBUILDDIR)
-GOVERSION := 1.6.0-alpine
+GOVERSION := 1.6.2-alpine
 
 ifndef GOOS
 	GOOS := $(shell go env GOOS)

--- a/cluster_update.go
+++ b/cluster_update.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/pulcy/quark/providers"
+)
+
+var (
+	cmdClusterUpdate = &cobra.Command{
+		Use: "update",
+		Run: updateCluster,
+	}
+
+	updateClusterFlags providers.ClusterInfo
+)
+
+func init() {
+	cmdClusterUpdate.Flags().StringVar(&updateClusterFlags.Domain, "domain", defaultDomain(), "Cluster domain")
+	cmdClusterUpdate.Flags().StringVar(&updateClusterFlags.Name, "name", "", "Cluster name")
+	cmdCluster.AddCommand(cmdClusterUpdate)
+}
+
+func updateCluster(cmd *cobra.Command, args []string) {
+	clusterInfoFromArgs(&updateClusterFlags, args)
+
+	provider := newProvider()
+	updateClusterFlags = provider.ClusterDefaults(updateClusterFlags)
+
+	if updateClusterFlags.Name == "" {
+		Exitf("Please specify a name\n")
+	}
+	err := provider.UpdateCluster(log, updateClusterFlags, newDnsProvider())
+	if err != nil {
+		Exitf("Failed to update cluster: %v\n", err)
+	}
+}

--- a/instance_list.go
+++ b/instance_list.go
@@ -57,7 +57,7 @@ func showInstances(cmd *cobra.Command, args []string) {
 		Exitf("Failed to fetch instance member data: %v\n", err)
 	}
 
-	lines := []string{"Name | Cluster IP | Public IP | Private IP | Machine ID | Options"}
+	lines := []string{"Name | Cluster IP | Public IP | Private IP | Machine ID | Options | Extra"}
 	for _, i := range instances {
 		cm, _ := clusterMembers.Find(i) // ignore errors
 		options := []string{}
@@ -65,7 +65,7 @@ func showInstances(cmd *cobra.Command, args []string) {
 			options = append(options, "etcd-proxy")
 		}
 		lbIP := strings.TrimSpace(i.LoadBalancerIPv4 + " " + i.LoadBalancerIPv6)
-		lines = append(lines, fmt.Sprintf("%s | %s | %s | %s | %s | %s", i.Name, i.ClusterIP, lbIP, i.PrivateIP, cm.MachineID, strings.Join(options, ",")))
+		lines = append(lines, fmt.Sprintf("%s | %s | %s | %s | %s | %s | %s", i.Name, i.ClusterIP, lbIP, i.PrivateIP, cm.MachineID, strings.Join(options, ","), strings.Join(i.Extra, ",")))
 	}
 	result := columnize.SimpleFormat(lines)
 	fmt.Println(result)

--- a/providers/cloud_provider.go
+++ b/providers/cloud_provider.go
@@ -72,6 +72,9 @@ type CloudProvider interface {
 	// Perform a reboot of the given instance
 	RebootInstance(instance ClusterInstance) error
 
+	// Update the instances of the cluster to all new services & formats
+	UpdateCluster(log *logging.Logger, info ClusterInfo, dnsProvider DnsProvider) error
+
 	ShowDomainRecords(domain string) error
 }
 

--- a/providers/digitalocean/update.go
+++ b/providers/digitalocean/update.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digitalocean
+
+import (
+	"github.com/op/go-logging"
+
+	"github.com/pulcy/quark/providers"
+)
+
+func (p *doProvider) UpdateCluster(log *logging.Logger, info providers.ClusterInfo, dnsProvider providers.DnsProvider) error {
+	return maskAny(NotImplementedError)
+}

--- a/providers/instance.go
+++ b/providers/instance.go
@@ -41,15 +41,18 @@ const (
 
 // ClusterInstance describes a single instance
 type ClusterInstance struct {
-	ID               string // Provider specific ID of the server (only used by provider, can be empty)
-	Name             string // Name of the instance as known by the provider
-	ClusterIP        string // IP address of the instance used for all private communication in the cluster
-	LoadBalancerIPv4 string // IPv4 address of the instance on which the load-balancer is listening (can be empty)
-	LoadBalancerIPv6 string // IPv6 address of the instance on which the load-balancer is listening (can be empty)
-	ClusterDevice    string // Device name of the nic that is configured for the ClusterIP
-	PrivateIP        string // IP address of the instance's private network (can be same as ClusterIP)
-	UserName         string // Account name used to SSH into this instance. (empty defaults to 'core')
-	OS               OSName // Name of the OS on the instance
+	ID               string   // Provider specific ID of the server (only used by provider, can be empty)
+	Name             string   // Name of the instance as known by the provider
+	ClusterIP        string   // IP address of the instance used for all private communication in the cluster
+	LoadBalancerIPv4 string   // IPv4 address of the instance on which the load-balancer is listening (can be empty)
+	LoadBalancerIPv6 string   // IPv6 address of the instance on which the load-balancer is listening (can be empty)
+	LoadBalancerDNS  string   // Provider hosted public DNS name of the instance on which the load-balancer is listening (can be empty)
+	ClusterDevice    string   // Device name of the nic that is configured for the ClusterIP
+	PrivateIP        string   // IP address of the instance's private network (can be same as ClusterIP)
+	PrivateDNS       string   // Provider hosted private DNS name of the instance's private network
+	UserName         string   // Account name used to SSH into this instance. (empty defaults to 'core')
+	OS               OSName   // Name of the OS on the instance
+	Extra            []string // Extra informational data
 }
 
 // Equals returns true of the given cluster instances refer to the same instance.
@@ -64,6 +67,9 @@ func (i ClusterInstance) String() string {
 	}
 	if i.LoadBalancerIPv6 != "" {
 		return i.LoadBalancerIPv6
+	}
+	if i.LoadBalancerDNS != "" {
+		return i.LoadBalancerDNS
 	}
 	return i.Name
 }
@@ -90,6 +96,9 @@ func (i ClusterInstance) runRemoteCommand(log *logging.Logger, command, stdin st
 	hostAddress := i.LoadBalancerIPv4
 	if hostAddress == "" {
 		hostAddress = i.LoadBalancerIPv6
+	}
+	if hostAddress == "" {
+		hostAddress = i.LoadBalancerDNS
 	}
 	if hostAddress == "" {
 		return "", maskAny(fmt.Errorf("don't have any address to communicate with instance %s", i.Name))

--- a/providers/scaleway/update.go
+++ b/providers/scaleway/update.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scaleway
+
+import (
+	"github.com/op/go-logging"
+
+	"github.com/pulcy/quark/providers"
+)
+
+func (p *scalewayProvider) UpdateCluster(log *logging.Logger, info providers.ClusterInfo, dnsProvider providers.DnsProvider) error {
+	instances, err := p.GetInstances(info)
+	if err != nil {
+		return maskAny(err)
+	}
+	if err := instances.ReconfigureTincCluster(log, nil); err != nil {
+		return maskAny(err)
+	}
+	return nil
+}

--- a/providers/tinc.go
+++ b/providers/tinc.go
@@ -153,8 +153,12 @@ func createTincConf(log *logging.Logger, i ClusterInstance, vpnName string, conn
 
 // createTincHostsConf creates a /etc/tinc/<vpnName>/hosts/<hostName> for the host of the given instance
 func createTincHostsConf(log *logging.Logger, i ClusterInstance, vpnName string) error {
+	address := i.PrivateDNS
+	if address == "" {
+		address = i.PrivateIP
+	}
 	lines := []string{
-		fmt.Sprintf("Address = %s", i.PrivateIP),
+		fmt.Sprintf("Address = %s", address),
 		fmt.Sprintf("Subnet = %s/32", i.ClusterIP),
 	}
 	confDir := path.Join("/etc/tinc", vpnName, "hosts")

--- a/providers/vagrant/update.go
+++ b/providers/vagrant/update.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vagrant
+
+import (
+	"github.com/op/go-logging"
+
+	"github.com/pulcy/quark/providers"
+)
+
+func (p *vagrantProvider) UpdateCluster(log *logging.Logger, info providers.ClusterInfo, dnsProvider providers.DnsProvider) error {
+	return maskAny(NotImplementedError)
+}

--- a/providers/vultr/update.go
+++ b/providers/vultr/update.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vultr
+
+import (
+	"github.com/op/go-logging"
+
+	"github.com/pulcy/quark/providers"
+)
+
+func (p *vultrProvider) UpdateCluster(log *logging.Logger, info providers.ClusterInfo, dnsProvider providers.DnsProvider) error {
+	return maskAny(NotImplementedError)
+}


### PR DESCRIPTION
`quark cluster update` updates settings of all instances of the cluster to their latest version.

For now this is implemented for Scaleway instances, where it updates the TINC hosts.
